### PR TITLE
Feat/#27 trade order

### DIFF
--- a/backend/src/main/java/com/example/cafe/CafeApplication.java
+++ b/backend/src/main/java/com/example/cafe/CafeApplication.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SecurityScheme(
 		name = "bearerAuth",
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 		scheme = "bearer",
 		bearerFormat = "JWT"
 )
+@EnableJpaAuditing
 @SpringBootApplication
 public class CafeApplication {
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/example/cafe/domain/trade/controller/admin/AdminTradeController.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/controller/admin/AdminTradeController.java
@@ -1,0 +1,40 @@
+package com.example.cafe.domain.trade.controller.admin;
+
+import com.example.cafe.domain.trade.domain.dto.request.AdminConfirmRequestDto;
+import com.example.cafe.domain.trade.domain.dto.response.OrderResponseDto;
+import com.example.cafe.domain.trade.service.admin.AdminTradeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/trade")
+@Tag(name = "Admin Trade API", description = "판매자가 거래에 대한 상태를 변경 가능합니다.")
+public class AdminTradeController {
+
+    private final AdminTradeService service;
+
+    @PostMapping("/confirm")
+    public ResponseEntity<OrderResponseDto> confirm(AdminConfirmRequestDto requestDto) {
+        return ResponseEntity.ok(service.adminConfirm(requestDto));
+    }
+
+    @PostMapping("/prepare")
+    public ResponseEntity<OrderResponseDto> prepare(AdminConfirmRequestDto requestDto) {
+        return ResponseEntity.ok(service.adminPrepareDelivery(requestDto));
+    }
+
+    @PostMapping("/in-delivery")
+    public ResponseEntity<OrderResponseDto> inDelivery(AdminConfirmRequestDto requestDto) {
+        return ResponseEntity.ok(service.adminSetInDelivery(requestDto));
+    }
+
+    @PostMapping("/post-delivery")
+    public ResponseEntity<OrderResponseDto> postDelivery(AdminConfirmRequestDto requestDto) {
+        return ResponseEntity.ok(service.adminSetPostDelivery(requestDto));
+    }
+}

--- a/backend/src/main/java/com/example/cafe/domain/trade/controller/user/UserCartController.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/controller/user/UserCartController.java
@@ -4,6 +4,8 @@ import com.example.cafe.domain.trade.domain.dto.request.ItemCartRequestDto;
 import com.example.cafe.domain.trade.domain.dto.response.CartListResponseDto;
 import com.example.cafe.domain.trade.domain.dto.response.ItemCartResponseDto;
 import com.example.cafe.domain.trade.service.user.UserCartService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,19 +13,23 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/cart")
+@Tag(name = "User Cart API", description = "사용자가 카트 보기, 카드에 상품 추가하기, 카트에 있는 상품 수정하기 기능을 제공합니다.")
 public class UserCartController {
     private final UserCartService service;
 
+    @Operation(summary = "카트(장바구니) 보기", description = "회원 카트에 있는 상품 목록을 제공합니다.")
     @GetMapping
     public ResponseEntity<CartListResponseDto> showCart(@RequestParam("memberId") Long memberId) {
         return ResponseEntity.ok(service.showCart(memberId));
     }
 
+    @Operation(summary = "카트에 상품 추가", description = "회원 카트에 상품을 추가하는 기능을 제공합니다.")
     @PostMapping("/add")
     public ResponseEntity<ItemCartResponseDto> addCart(@RequestBody ItemCartRequestDto addItem) {
         return ResponseEntity.ok(service.addItemToCart(addItem));
     }
 
+    @Operation(summary = "카트에 있는 상품 수량 수정", description = "회원 카트에 있는 상품의 수량을 수정할 수 있습니다. 수량이 0 이면 삭제.")
     @PostMapping("/edit")
     public ResponseEntity<ItemCartResponseDto> editCart(@RequestBody ItemCartRequestDto editItem) {
         return ResponseEntity.ok(service.editItemToCart(editItem));

--- a/backend/src/main/java/com/example/cafe/domain/trade/controller/user/UserTradeController.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/controller/user/UserTradeController.java
@@ -3,6 +3,8 @@ package com.example.cafe.domain.trade.controller.user;
 import com.example.cafe.domain.trade.domain.dto.request.OrderRequestItemDto;
 import com.example.cafe.domain.trade.domain.dto.response.OrderResponseDto;
 import com.example.cafe.domain.trade.service.user.UserTradeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,14 +12,17 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/order")
+@Tag(name = "User Trade API", description = "사용자가 카드에 있는 상품을 주문하거나, 상품을 단건으로 주문하는 기능을 제공합니다.")
 public class UserTradeController {
     private final UserTradeService service;
 
+    @Operation(summary = "카트에 있는 상품 주문", description = "회원이 카트에 있는 상품을 주문할 수 있습니다.")
     @PostMapping("/cart")
     public ResponseEntity<OrderResponseDto> orderWithCart(@RequestParam("memberId") Long memberId) {
         return ResponseEntity.ok(service.tradeWithCart(memberId));
     }
 
+    @Operation(summary = "카트에 넣지 않고 바로 상품 주문", description = "회원이 상품을 바로 주문할 수 있습니다.")
     @PostMapping("/item")
     public ResponseEntity<OrderResponseDto> orderWithItem(@RequestBody OrderRequestItemDto requestItemDto) {
         return ResponseEntity.ok(service.tradeWithItemInfo(requestItemDto));

--- a/backend/src/main/java/com/example/cafe/domain/trade/domain/dto/request/AdminConfirmRequestDto.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/domain/dto/request/AdminConfirmRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.cafe.domain.trade.domain.dto.request;
+
+import lombok.Data;
+
+@Data
+public class AdminConfirmRequestDto {
+    private Long adminId;
+    private String tradeUUID;
+    private boolean changeToDeliveryReady;
+}

--- a/backend/src/main/java/com/example/cafe/domain/trade/domain/dto/request/CancelRequestDto.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/domain/dto/request/CancelRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.cafe.domain.trade.domain.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class CancelRequestDto {
+    private String tradeUUID;
+    private List<CancelItemRequest> cancelItemList;
+
+    @Data
+    @AllArgsConstructor
+    public static class CancelItemRequest {
+        private Long itemId;
+        private Integer quantity;
+    }
+}

--- a/backend/src/main/java/com/example/cafe/domain/trade/domain/entity/TradeStatus.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/domain/entity/TradeStatus.java
@@ -1,7 +1,6 @@
 package com.example.cafe.domain.trade.domain.entity;
 
 public enum TradeStatus {
-    WANT("장바구니"), //(장바구니 담겨있는 상태)
     BUY("구매요청"), //(구매하기 요청 후 결제 완료 이전 상태)
     PAY("결제완료"), //(결제 완료 이후 상태)
     BEFORE_DELIVERY("배송대기"), // (배송 대기)

--- a/backend/src/main/java/com/example/cafe/domain/trade/portone/controller/PortoneController.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/portone/controller/PortoneController.java
@@ -2,6 +2,7 @@ package com.example.cafe.domain.trade.portone.controller;
 
 import com.example.cafe.domain.trade.portone.domain.dto.WebHook;
 import com.example.cafe.domain.trade.portone.service.PortoneService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/portone")
 @RequiredArgsConstructor
+@Tag(name = "PortOne WebHook", description = "결제에 성공하면, 해당 정보가 웹훅으로 전송됩니다.")
 public class PortoneController {
 
     private final PortoneService portoneService;

--- a/backend/src/main/java/com/example/cafe/domain/trade/portone/service/PortoneService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/portone/service/PortoneService.java
@@ -76,7 +76,6 @@ public class PortoneService {
         }
     }
 
-    @Transactional
     public void validateWebHook(WebHook webHook) {
         IamportResponse<Payment> paymentIamportResponse;
 
@@ -100,7 +99,6 @@ public class PortoneService {
             findTrade.setTradeStatus(PAY);
             log.info("response.amount:{}", paymentIamportResponse.getResponse().getAmount());
         }
-
 
         log.info("web hook 인증 결과 이상 없음, TradeId : [{}] 결제 완료.", findTrade.getId());
     }

--- a/backend/src/main/java/com/example/cafe/domain/trade/service/admin/AdminTradeService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/admin/AdminTradeService.java
@@ -1,15 +1,117 @@
 package com.example.cafe.domain.trade.service.admin;
 
-import com.example.cafe.domain.trade.repository.TradeItemRepository;
+import com.example.cafe.domain.member.repository.MemberRepository;
+import com.example.cafe.domain.trade.domain.dto.request.AdminConfirmRequestDto;
+import com.example.cafe.domain.trade.domain.dto.response.OrderResponseDto;
+import com.example.cafe.domain.trade.domain.entity.Trade;
+import com.example.cafe.domain.trade.domain.entity.TradeStatus;
+import com.example.cafe.domain.trade.portone.service.PortoneService;
 import com.example.cafe.domain.trade.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AdminTradeService {
 
     private final TradeRepository tradeRepository;
-    private final TradeItemRepository tradeItemRepository;
+    private final MemberRepository memberRepository;
+    private final PortoneService portoneService;
+
+
+    //주문이 PAY 이면 -> TradeStatus 변경 (2시 이전 , 2시 이후)
+    public OrderResponseDto adminConfirm(AdminConfirmRequestDto confirmRequestDto) {
+        Trade trade = getTrade(confirmRequestDto);
+
+        if (!trade.getTradeStatus().equals(TradeStatus.PAY)) {
+            throw new RuntimeException("결제 완료 상태에서만 배송 상태로 변경할 수 있습니다.");
+        }
+        LocalDateTime updatedDate = trade.getTradeUpdatedDate();
+        LocalDateTime twoPmToday = updatedDate.toLocalDate().atTime(14, 0);
+
+        if (updatedDate.isBefore(twoPmToday)) {
+            //2시 이전
+            trade.setTradeStatus(TradeStatus.BEFORE_DELIVERY);
+        } else {
+            //2시 이후
+            trade.setTradeStatus(TradeStatus.PREPARE_DELIVERY);
+        }
+
+        return new OrderResponseDto(
+                trade.getId(),
+                trade.getTradeStatus(),
+                trade.getTotalPrice(),
+                trade.getTradeUUID()
+        );
+    }
+
+    // PREPARE_DELIVERY -> BEFORE_DELIVERY 상태 변경
+
+    public OrderResponseDto adminPrepareDelivery(AdminConfirmRequestDto prepareRequestDto) {
+        Trade trade = getTrade(prepareRequestDto);
+
+        if (!trade.getTradeStatus().equals(TradeStatus.PREPARE_DELIVERY)) {
+            throw new RuntimeException("배송 대기 상태에서만 배송 준비로 상태 변경이 가능합니다.");
+        }
+
+        trade.setTradeStatus(TradeStatus.BEFORE_DELIVERY);
+
+        return new OrderResponseDto(
+                trade.getId(),
+                trade.getTradeStatus(),
+                trade.getTotalPrice(),
+                trade.getTradeUUID()
+        );
+    }
+
+    public OrderResponseDto adminSetInDelivery(AdminConfirmRequestDto inDeliveryRequestDto) {
+        Trade trade = getTrade(inDeliveryRequestDto);
+
+        if (!trade.getTradeStatus().equals(TradeStatus.BEFORE_DELIVERY)) {
+            throw new RuntimeException("배송 대기 상태에서만 배송 중 으로 변경 가능합니다.");
+        }
+
+        trade.setTradeStatus(TradeStatus.IN_DELIVERY);
+
+        return new OrderResponseDto(
+                trade.getId(),
+                trade.getTradeStatus(),
+                trade.getTotalPrice(),
+                trade.getTradeUUID()
+        );
+    }
+
+    public OrderResponseDto adminSetPostDelivery(AdminConfirmRequestDto postDeliveryRequestDto) {
+        Trade trade = getTrade(postDeliveryRequestDto);
+
+        if (!trade.getTradeStatus().equals(TradeStatus.IN_DELIVERY)) {
+            throw new RuntimeException("배송 중 상태에서만 배송 완료로 변경 가능합니다.");
+        }
+
+        trade.setTradeStatus(TradeStatus.POST_DELIVERY);
+
+        return new OrderResponseDto(
+                trade.getId(),
+                trade.getTradeStatus(),
+                trade.getTotalPrice(),
+                trade.getTradeUUID()
+        );
+    }
+
+    private Trade getTrade(AdminConfirmRequestDto requestDto) {
+        if (!memberRepository.findById(requestDto.getAdminId())
+                .orElseThrow(() -> new RuntimeException("해당 사용자를 찾을 수 없습니다."))
+                .getAuthority().equals("ADMIN")) {
+            throw new RuntimeException("관리자 권한의 사용자만 거래 상태를 변경할 수 있습니다.");
+        }
+
+        Trade trade = tradeRepository.findByTradeUUID(requestDto.getTradeUUID())
+                .orElseThrow(() -> new RuntimeException("TradeUUID : [" + requestDto.getTradeUUID() + "] 해당 거래를 찾을 수 없습니다."));
+        return trade;
+    }
 }
 

--- a/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserCartService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserCartService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.cafe.domain.trade.domain.dto.response.CartListResponseDto.*;

--- a/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserCartService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserCartService.java
@@ -10,17 +10,13 @@ import com.example.cafe.domain.trade.domain.dto.response.CartListResponseDto;
 import com.example.cafe.domain.trade.domain.dto.response.ItemCartResponseDto;
 import com.example.cafe.domain.trade.domain.entity.Cart;
 import com.example.cafe.domain.trade.domain.entity.CartItem;
-import com.example.cafe.domain.trade.repository.CartItemRepository;
 import com.example.cafe.domain.trade.repository.CartRepository;
-import com.example.cafe.domain.trade.repository.TradeItemRepository;
-import com.example.cafe.domain.trade.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.cafe.domain.trade.domain.dto.response.CartListResponseDto.*;
@@ -30,10 +26,7 @@ import static com.example.cafe.domain.trade.domain.dto.response.ItemCartResponse
 @RequiredArgsConstructor
 @Transactional
 public class UserCartService {
-    private final TradeRepository tradeRepository;
-    private final TradeItemRepository tradeItemRepository;
     private final CartRepository cartRepository;
-    private final CartItemRepository cartItemRepository;
     private final ItemRepository itemRepository;
     private final MemberRepository memberRepository;
 

--- a/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserCartService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserCartService.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.cafe.domain.trade.domain.dto.response.CartListResponseDto.*;

--- a/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserTradeService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserTradeService.java
@@ -12,9 +12,6 @@ import com.example.cafe.domain.trade.domain.entity.Trade;
 import com.example.cafe.domain.trade.domain.entity.TradeItem;
 import com.example.cafe.domain.trade.domain.entity.TradeStatus;
 import com.example.cafe.domain.trade.portone.service.PortoneService;
-import com.example.cafe.domain.trade.repository.CartItemRepository;
-import com.example.cafe.domain.trade.repository.CartRepository;
-import com.example.cafe.domain.trade.repository.TradeItemRepository;
 import com.example.cafe.domain.trade.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,9 +33,6 @@ import static com.example.cafe.domain.trade.domain.entity.TradeStatus.*;
 public class UserTradeService {
 
     private final TradeRepository tradeRepository;
-    private final TradeItemRepository tradeItemRepository;
-    private final CartRepository cartRepository;
-    private final CartItemRepository cartItemRepository;
     private final ItemRepository itemRepository;
     private final PortoneService portoneService;
     private final MemberRepository memberRepository;
@@ -51,10 +45,14 @@ public class UserTradeService {
 
     public OrderResponseDto tradeWithCart(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("멤버를 찾을 수 없습니다"));
-        List<CartItem> cartItems = member.getCart().getCartItems();
-
+        List<CartItem> cartItems;
+        try {
+            cartItems = member.getCart().getCartItems();
+        } catch (NullPointerException e) {
+            throw new RuntimeException("장바구니 카트가 비어있습니다.");
+        }
         if (cartItems.isEmpty()) {
-            throw new RuntimeException("장바구니 카드가 비어있습니다.");
+            throw new RuntimeException("장바구니 카트가 비어있습니다.");
         }
 
         for (CartItem cartItem : cartItems) {
@@ -63,14 +61,12 @@ public class UserTradeService {
             }
         }
 
-        Trade trade = Trade.builder()
-                .member(member)
-                .tradeStatus(BUY) // 거래 상태 초기화
-                .tradeItems(new ArrayList<>()) // 리스트 초기화
-                .build();
+        Trade trade = makeTrade(member, BUY);
 
+        //member 에 trade 추가
         member.getTrades().add(trade);
 
+        //trade 에 장바구니에 있는 상품 전체 추가
         for (CartItem cartItem : cartItems) {
             Item item = itemRepository.findById(cartItem.getItem().getId()).orElseThrow(() -> new RuntimeException("주문하고자 하는 상품을 찾을 수 없습니다."));
 
@@ -88,11 +84,14 @@ public class UserTradeService {
             trade.addTradeItem(tradeItem);
         }
 
+        //trade 에 주문 상품 총 합 가격 설정
         trade.setTotalPrice(calculateTotalPrice(trade.getTradeItems()));
 
+        //trade 에 uuid 값 생성 후 추가
         String tradeUUID = generateTradeUUID();
         trade.setTradeUUID(tradeUUID);
 
+        //portone PG 사에 결제 요청 정보 저장
         try {
             portoneService.prePurchase(tradeUUID,new BigDecimal(trade.getTotalPrice()));
         } catch (Exception e) {
@@ -120,12 +119,10 @@ public class UserTradeService {
             throw new RuntimeException("요청한 상품 중 재고가 부족한 상품이 있습니다.");
         }
 
-        Trade trade = Trade.builder()
-                .member(member)
-                .tradeStatus(TradeStatus.BUY)
-                .tradeItems(new ArrayList<>())
-                .build();
+        // Trade 생성
+        Trade trade = makeTrade(member, TradeStatus.BUY);
 
+        // member 에 trade 저장
         member.getTrades().add(trade);
 
         Item item = itemRepository.findById(requestItemDto.getItemId()).orElseThrow(() -> new RuntimeException("주문 하고자 하는 상품을 찾을 수 없습니다."));
@@ -164,6 +161,7 @@ public class UserTradeService {
     }
 
     // 포트원 PG 사 대신하여 결제 되었다고 처리할 수 있는 메서드
+
     public void processPayment(String uuid, int payAmount) {
 
         //Trade 조회
@@ -190,13 +188,23 @@ public class UserTradeService {
 
         trade.setTradeStatus(PAY);
     }
-
     public void rollBackProductQuantity(Trade trade) {
         List<TradeItem> tradeItems = trade.getTradeItems();
         tradeItems.forEach(tradeItem -> {
             tradeItem.getItem().setStock(tradeItem.getItem().getStock() + tradeItem.getQuantity());
             tradeItem.getItem().autoCheckQuantityForSetStatus();
         });
+    }
+
+    private Trade makeTrade(Member member, TradeStatus buy) {
+        Trade trade = Trade.builder()
+                .member(member)
+                .tradeStatus(buy)
+                .tradeItems(new ArrayList<>())
+                .address(member.getAddress())
+                .email(member.getEmail())
+                .build();
+        return trade;
     }
 
 

--- a/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserTradeService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserTradeService.java
@@ -64,9 +64,12 @@ public class UserTradeService {
         }
 
         Trade trade = Trade.builder()
+                .member(member)
                 .tradeStatus(BUY) // 거래 상태 초기화
                 .tradeItems(new ArrayList<>()) // 리스트 초기화
                 .build();
+
+        member.getTrades().add(trade);
 
         for (CartItem cartItem : cartItems) {
             Item item = itemRepository.findById(cartItem.getItem().getId()).orElseThrow(() -> new RuntimeException("주문하고자 하는 상품을 찾을 수 없습니다."));
@@ -112,16 +115,17 @@ public class UserTradeService {
     }
 
     public OrderResponseDto tradeWithItemInfo(OrderRequestItemDto requestItemDto) {
+        Member member = memberRepository.findById(requestItemDto.getMemberId()).orElseThrow(() -> new RuntimeException("멤버를 찾을 수 없습니다"));
         if (!stockValidCheck(requestItemDto)) {
             throw new RuntimeException("요청한 상품 중 재고가 부족한 상품이 있습니다.");
         }
 
         Trade trade = Trade.builder()
+                .member(member)
                 .tradeStatus(TradeStatus.BUY)
                 .tradeItems(new ArrayList<>())
                 .build();
 
-        Member member = memberRepository.findById(requestItemDto.getMemberId()).orElseThrow(() -> new RuntimeException("해당 사용자를 찾을 수 없습니다."));
         member.getTrades().add(trade);
 
         Item item = itemRepository.findById(requestItemDto.getItemId()).orElseThrow(() -> new RuntimeException("주문 하고자 하는 상품을 찾을 수 없습니다."));


### PR DESCRIPTION
## 연관된 이슈

> #27

## 작업 내용

> 주문 생성 후 관리자가 주문 상태 변경 기능 도입
- 주문 요청 후 결제 진행
    - → 상태 : BUY → PAY (성공) / BUY → REFUSED (실패)

- 주문 요청 후 관리자 승인 - 관리자 페이지에서.
    - → 상태 : PAY → BEFORE_DELIVERY (2시 이전) / PAY → PREPARE_DELIVERY (2시 이후) / PAY → REFUSED (관리자 거절)

- 관리자 승인 후 주문 배송 준비로 상태 변경 → 2시 이전 : 배송 대기 / 2시 이후 : 배송 준비
- 관리자는 배송 준비 상태인 주문에 대해 배송 중으로 상태 변경 가능 - 관리자 페이지에서.
    - → 상태 : BEFORE_DELIVERY → IN_DELIVERY (배송 중)
- 관리자는 배송 중인 상품에 대해 배송 완료로 상태 변경 가능 - 관리자 페이지에서.
    - → 상태 : IN_DELIVERY → POST_DELIVERY (배송 완료)
 

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

