### PR TITLE
fix: 관리자 주문 현황 수정 - 배송완료, 주문 취소 목록 출력

### DIFF
--- a/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserTradeAtomicUpdateService.java
+++ b/backend/src/main/java/com/example/cafe/domain/trade/service/user/UserTradeAtomicUpdateService.java
@@ -427,7 +427,7 @@ public class UserTradeAtomicUpdateService {
 
             // • 취소된 상품들은 별도의 새 Trade(상태 REFUND)로 생성하여 저장
             Trade cancelledTrade = makeTrade(member, TradeStatus.REFUND);
-            cancelledTrade.setTradeUUID(trade.getTradeUUID());
+            cancelledTrade.setTradeUUID("refund" + trade.getTradeUUID());
             cancelledTrade.setTradeItems(cancelledTradeItems);
             int cancelledTotalPrice = cancelledTradeItems.stream()
                     .mapToInt(TradeItem::getPrice)

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -294,6 +294,16 @@ export default function OrderPage() {
               </h3>
               {renderOrderGroup(orders.inDeliveryList, "inDeliveryList")}
             </section>
+            <section className="mb-6">
+              <h3 className="text-xl font-semibold mb-2">
+                배송 완료 (POST_DELIVERY)
+              </h3>
+              {renderOrderGroup(orders.postDeliveryList, "postDeliveryList")}
+            </section>
+            <section className="mb-6">
+              <h3 className="text-xl font-semibold mb-2">주문 취소 (CANCEL)</h3>
+              {renderOrderGroup(orders.refusedList, "refusedList")}
+            </section>
           </div>
         ) : null}
       </main>


### PR DESCRIPTION
## 연관된 이슈

> #27
> 

## 작업 내용

> 결제한 주문 수정 후 관리자 승인 시 동일한 uuid 값으로 2개의 Trade 가 저장되는 버그 FIX
> 

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
